### PR TITLE
Add more Binance proxy endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # API-Test
+
+This repository contains a minimal Flask server that proxies a few Binance API endpoints.
+
+## Setup
+
+1. Create and activate a Python virtual environment (optional but recommended).
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the server:
+   ```bash
+   python server.py
+   ```
+   The server listens on port `5000` by default.
+
+## Example Endpoints
+
+- `/binance/ping` – Check connectivity with the Binance API.
+- `/binance/price/<symbol>` – Get the latest price for a trading pair (e.g. `BTCUSDT`).
+- `/binance/depth/<symbol>` – Get order book data. Optional `limit` query param.
+- `/binance/trades/<symbol>` – Get recent trades. Optional `limit` query param.
+- `/binance/klines/<symbol>` – Get candlestick data. Optional `interval` and `limit` query params.
+- `/binance/ticker24hr/<symbol>` – Get 24‑hour ticker statistics.
+
+You can override the Binance base URL by setting the `BINANCE_API_BASE` environment variable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/server.py
+++ b/server.py
@@ -1,0 +1,91 @@
+import os
+from flask import Flask, jsonify, request
+import requests
+
+BINANCE_API_BASE = os.environ.get('BINANCE_API_BASE', 'https://api.binance.com')
+
+app = Flask(__name__)
+
+@app.route('/binance/ping')
+def binance_ping():
+    url = f"{BINANCE_API_BASE}/api/v3/ping"
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.RequestException as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/binance/price/<symbol>')
+def binance_price(symbol):
+    url = f"{BINANCE_API_BASE}/api/v3/ticker/price"
+    try:
+        resp = requests.get(url, params={'symbol': symbol.upper()}, timeout=5)
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.RequestException as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/binance/depth/<symbol>')
+def binance_depth(symbol):
+    url = f"{BINANCE_API_BASE}/api/v3/depth"
+    limit = request.args.get('limit', '5')
+    try:
+        resp = requests.get(
+            url,
+            params={'symbol': symbol.upper(), 'limit': limit},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.RequestException as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/binance/trades/<symbol>')
+def binance_trades(symbol):
+    url = f"{BINANCE_API_BASE}/api/v3/trades"
+    limit = request.args.get('limit', '5')
+    try:
+        resp = requests.get(
+            url,
+            params={'symbol': symbol.upper(), 'limit': limit},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.RequestException as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/binance/klines/<symbol>')
+def binance_klines(symbol):
+    url = f"{BINANCE_API_BASE}/api/v3/klines"
+    interval = request.args.get('interval', '1h')
+    limit = request.args.get('limit', '500')
+    try:
+        resp = requests.get(
+            url,
+            params={'symbol': symbol.upper(), 'interval': interval, 'limit': limit},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.RequestException as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/binance/ticker24hr/<symbol>')
+def binance_ticker24hr(symbol):
+    url = f"{BINANCE_API_BASE}/api/v3/ticker/24hr"
+    try:
+        resp = requests.get(
+            url,
+            params={'symbol': symbol.upper()},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return jsonify(resp.json())
+    except requests.RequestException as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))
+


### PR DESCRIPTION
## Summary
- extend Flask server with endpoints for order book, recent trades, klines, and 24‑hr ticker
- document these endpoints in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856c755c61c83289ff50980bec91efb